### PR TITLE
Arreglar bug de reasignación

### DIFF
--- a/src/asignacion_aulica/frontend/config_horarios.py
+++ b/src/asignacion_aulica/frontend/config_horarios.py
@@ -6,6 +6,7 @@ las Actividades/Materias de la Universidad.
 @author: Cristian
 """
 
+import traceback
 import flet as ft
 from pandas import DataFrame
 
@@ -295,6 +296,7 @@ class UI_Config_Horarios():
             # Se actualizan los elementos de la interfaz.
             self.actualizar_tabla()
         except Exception as exc:
+            print(traceback.format_exc())
             mensaje_error: str = str(exc)
             self.alertar(mensaje_error)
     

--- a/src/asignacion_aulica/frontend/funciones_de_traduccion.py
+++ b/src/asignacion_aulica/frontend/funciones_de_traduccion.py
@@ -74,11 +74,9 @@ def traducir_clases(clases_frontend:DataFrame):
     clases_backend['día'] = clases_frontend['Día'].map(mapeador_de_dias)
     clases_backend['horario_inicio'] = clases_frontend['Horario de inicio'].apply(horario_simple_a_minutos)
     clases_backend['horario_fin'] = clases_frontend['Horario de fin'].apply(horario_simple_a_minutos)
-    clases_backend['cantidad_de_alumnos']   =   clases_frontend['Cantidad de alumnos']
-
+    clases_backend['cantidad_de_alumnos'] = clases_frontend['Cantidad de alumnos']
     clases_backend['equipamiento_necesario'] = clases_frontend['Equipamiento necesario'].astype(str).map(parsear_equipamiento)
-    #clases_backend['equipamiento_necesario']=   list(map(parsear_equipamiento, clases_frontend['Equipamiento necesario']))
-    clases_backend['edificio_preferido']    =   clases_frontend['Edificio preferencial']
-    clases_backend['aula_asignada']         =   None
+    clases_backend['edificio_preferido'] = clases_frontend['Edificio preferencial']
+    clases_backend['aula_asignada'] = clases_frontend['Aula asignada (índices)']
 
     return clases_backend

--- a/src/asignacion_aulica/lógica_de_asignación/asignar.py
+++ b/src/asignacion_aulica/lógica_de_asignación/asignar.py
@@ -124,6 +124,10 @@ def resolver_problema_de_asignación(
         otra cosa, en tuplas (aula, día, inicio, fin).
     :return: Una lista con el número de aula asignada a cada clase.
     '''
+
+    if clases.empty:
+        return []
+
     # Crear modelo, variables, restricciones, y penalizaciones
     modelo = cp_model.CpModel()
     asignaciones = crear_matriz_de_asignaciones(clases, aulas, aulas_dobles, aulas_ocupadas, modelo)

--- a/src/asignacion_aulica/lógica_de_asignación/preferencias.py
+++ b/src/asignacion_aulica/lógica_de_asignación/preferencias.py
@@ -77,6 +77,10 @@ def obtener_cantidad_de_clases_fuera_del_edificio_preferido(
             cantidad_de_clases_fuera_del_edificio_preferido -= 1
             cota_superior -= 1
 
+    # Evitamos que la cota superior sea 0 porque luego se usa para dividir
+    if cota_superior == 0:
+        cota_superior = 1
+
     return cantidad_de_clases_fuera_del_edificio_preferido, cota_superior
 
 def obtener_cantidad_de_alumnos_fuera_del_aula(

--- a/tests/pytest/lógica_de_asignación/test_asignaciones_manuales.py
+++ b/tests/pytest/lógica_de_asignación/test_asignaciones_manuales.py
@@ -173,3 +173,30 @@ def test_asignaciones_manuales_que_inclumplen_restricciones(aulas, clases):
     assert clases.at[6, 'aula_asignada'] == 1
     assert clases.at[7, 'aula_asignada'] == 3
     assert clases.at[8, 'aula_asignada'] == 3
+
+@pytest.mark.aulas(*[{}]*5) # Re críptico pero esto significa 5 aulas con valores deafut
+@pytest.mark.clases(
+    dict(aula_asignada=1),
+    dict(aula_asignada=3),
+    dict(aula_asignada=0),
+    dict(aula_asignada=2),
+    dict(aula_asignada=4),
+    dict(aula_asignada=1),
+    dict(aula_asignada=1),
+)
+def test_todas_las_aulas_asignadas_manuales(aulas, clases):
+    '''
+    Verificar que cuando todas las asignaciones son manuales, se maneja
+    correctamente (no saltan excepciones ni se cambian las asignaciones).
+    '''
+
+    asignar(clases, aulas)
+
+    assert clases.at[0, 'aula_asignada'] == 1
+    assert clases.at[1, 'aula_asignada'] == 3
+    assert clases.at[2, 'aula_asignada'] == 0
+    assert clases.at[3, 'aula_asignada'] == 2
+    assert clases.at[4, 'aula_asignada'] == 4
+    assert clases.at[5, 'aula_asignada'] == 1
+    assert clases.at[6, 'aula_asignada'] == 1
+


### PR DESCRIPTION
Esto quedó muy atado con alambres porque no me pareció que valía la pena dedicarle más tiempo para arreglarlo bien, siendo que falta hacer las grandes refactorizaciones todavía. De hecho, esas refactorizaciones se pueden hacer teniendo en cuenta estas cosas de entrada. Tuve que contenerme un montón de no ponerme a refactorizar, pero ví un montón de problemas, por ejemplo que no se maneja el caso de que haya varias aulas con el mismo nombre aunque en distintos edificios.

Muy posiblemente convenga crear un issue/añadir un comentario a un issue para tener esto en cuenta. Si se guardan las aulas asignadas por el nombre y edificio, tienen que transformarse estos datos a como lo usa backend (índices) o que backend use la misma forma de identificar aulas, y si se guardan las aulas asignadas por el índice, tiene que tenerse en cuenta el caso de que se cambien los índices de las aulas (cuando se agregan nuevas o si cambian de orden). Y, en ambos casos debe considerarse qué hacer cuando se borran aulas que estén asignadas manualmente.